### PR TITLE
fix db error while buying

### DIFF
--- a/commands/money/buy.js
+++ b/commands/money/buy.js
@@ -10,7 +10,7 @@ exports.run = async (client, message, args = []) => {
         const shops = [Equipments, Foods, KeyItems, CurrencyShop];
 
         if (!args[0]) return sendMessage(client, message, `You need to provide the name of the item you want to buy.`);
-        const commandArgs = args?.join(' ').match(/(\w+(?:\s+\w+)*)/);
+        const commandArgs = args.join(' ').match(/(\w+(?:\s+\w+)*)/);
 
         for (let i = 0; i < shops.length; i++) {
             const item = await shops[i].findOne({ where: { name: { [Op.like]: commandArgs[1] } } });

--- a/commands/money/buy.js
+++ b/commands/money/buy.js
@@ -9,13 +9,11 @@ exports.run = async (client, message, args = []) => {
         const { Op } = require('sequelize');
         const shops = [Equipments, Foods, KeyItems, CurrencyShop];
 
-        // Disable because bugs
-        return sendMessage(client, message, `Buying is currently experiencing some bugs and has been disabled. For  more info: <https://github.com/Glazelf/NinigiBot/issues/132>.`);
-
         if (!args[0]) return sendMessage(client, message, `You need to provide the name of the item you want to buy.`);
-        const commandArgs = args[0].match(/(\w+)\s*([\s\S]*)/);
+        const commandArgs = args?.join(' ').match(/(\w+(?:\s+\w+)*)/);
+
         for (let i = 0; i < shops.length; i++) {
-            const item = await shops[i].findOne({ where: { name: { [Op.like]: commandArgs } } });
+            const item = await shops[i].findOne({ where: { name: { [Op.like]: commandArgs[1] } } });
             if (item) {
                 if (item.cost === 0) return sendMessage(client, message, `That item doesn't exist.`);
                 let dbBalance = await bank.currency.getBalance(message.member.id);
@@ -57,7 +55,7 @@ module.exports.config = {
     name: "buy",
     aliases: [],
     description: "Buy an item from the shop.",
-    optiosn: [{
+    options: [{
         name: "item-name",
         type: "STRING",
         description: "The name of the item you want to buy.",


### PR DESCRIPTION
fixes #132 
Matches the item name from the rejoined args array
the `SQLITE_ERROR: near ","` was caused because it was passing the entire regex match array as the string to match against and sqlite didnt like that

also while trying to find the names of equipments i found that the ?shop command does not correctly print the names and instead sends the list of items as
```
[object Promise]
[object Promise]
[object Promise]
[object Promise]
[object Promise]
```