### PR TITLE
Minesweeper Rework

### DIFF
--- a/commands/other/minesweeper.js
+++ b/commands/other/minesweeper.js
@@ -6,7 +6,6 @@ import {
     SlashCommandIntegerOption,
     SlashCommandBooleanOption
 } from "discord.js";
-import Minesweeper from "discord.js-minesweeper";
 import sendMessage from "../../util/sendMessage.js";
 import globalVars from "../../objects/globalVars.json" with { type: "json" };
 
@@ -35,37 +34,19 @@ export default async (interaction, ephemeral) => {
             mines = minesArg;
         };
     };
-    const minesweeper = new Minesweeper({
-        rows: rows,
-        columns: columns,
-        mines: mines,
-        emote: 'bomb',
-        returnType: 'matrix',
-    });
-    let bombEmote = "💣";
-    let spoilerEmote = "⬛";
-    let matrix = minesweeper.start();
-    matrix.forEach(arr => {
-        for (let i = 0; i < arr.length; i++) {
-            arr[i] = arr[i].replace("|| :bomb: ||", bombEmote).replace("|| :zero: ||", "0️⃣").replace("|| :one: ||", "1️⃣").replace("|| :two: ||", "2️⃣").replace("|| :three: ||", "3️⃣").replace("|| :four: ||", "4️⃣").replace("|| :five: ||", "5️⃣").replace("|| :six: ||", "6️⃣").replace("|| :seven: ||", "7️⃣").replace("|| :eight: ||", "8️⃣");
-        };
-    });
+    let placeholderEmoji = "⬛";
     let buttonRowArray = [];
-    let buttonIndex = 0;
-    let rowIndex = 0;
-    matrix.forEach(arr => {
+    for (let rowIndex = 0; rowIndex < rows; rowIndex++) {
         let buttonRow = new ActionRowBuilder();
-        arr.forEach(element => {
+        for (let columnIndex = 0; columnIndex < columns; columnIndex++) {
             const mineButton = new ButtonBuilder()
-                .setCustomId(`minesweeper${rowIndex}-${buttonIndex}-${element}`)
+                .setCustomId(`minesweeper${rowIndex}-${columnIndex}-${placeholderEmoji}`)
                 .setStyle(ButtonStyle.Primary)
-                .setEmoji(spoilerEmote);
+                .setEmoji(placeholderEmoji);
             buttonRow.addComponents(mineButton);
-            buttonIndex += 1;
-        });
-        rowIndex += 1;
+        };
         buttonRowArray.push(buttonRow);
-    });
+    };
 
     let returnString = `Here is your minesweeper grid!`;
     if (correctionString.length > 0) {

--- a/commands/other/minesweeper.js
+++ b/commands/other/minesweeper.js
@@ -48,7 +48,7 @@ export default async (interaction, ephemeral) => {
         buttonRowArray.push(buttonRow);
     };
 
-    let returnString = `Here is your minesweeper grid!`;
+    let returnString = `## Here is your minesweeper grid!`;
     if (correctionString.length > 0) {
         returnString += `\n${correctionString}`;
     } else {

--- a/commands/other/minesweeper.js
+++ b/commands/other/minesweeper.js
@@ -40,7 +40,7 @@ export default async (interaction, ephemeral) => {
         let buttonRow = new ActionRowBuilder();
         for (let columnIndex = 0; columnIndex < columns; columnIndex++) {
             const mineButton = new ButtonBuilder()
-                .setCustomId(`minesweeper${rowIndex}-${columnIndex}-${placeholderEmoji}`)
+                .setCustomId(`minesweeper${rowIndex}-${columnIndex}-${placeholderEmoji}-${mines}`)
                 .setStyle(ButtonStyle.Primary)
                 .setEmoji(placeholderEmoji);
             buttonRow.addComponents(mineButton);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -10,12 +10,12 @@ import {
     TextInputBuilder,
     TextInputStyle
 } from "discord.js";
-import logger from "../util/logger.js";
-import globalVars from "../objects/globalVars.json" with { type: "json" };
-import config from "../config.json" with { type: "json" };
-import sendMessage from "../util/sendMessage.js";
 import axios from "axios";
 import fs from "fs";
+import logger from "../util/logger.js";
+import sendMessage from "../util/sendMessage.js";
+import globalVars from "../objects/globalVars.json" with { type: "json" };
+import config from "../config.json" with { type: "json" };
 // Pokémon
 import { Dex } from '@pkmn/dex';
 import { Dex as DexSim } from '@pkmn/sim';
@@ -24,9 +24,9 @@ import getPokemon from "../util/pokemon/getPokemon.js";
 import getWhosThatPokemon from "../util/pokemon/getWhosThatPokemon.js";
 // Monster Hunter
 import getMHMonster from "../util/mh/getMonster.js";
+import getMHQuests from "../util/mh/getQuests.js";
 import MHMonstersJSON from "../submodules/monster-hunter-DB/monsters.json" with { type: "json"};
 import MHQuestsJSON from "../submodules/monster-hunter-DB/quests.json" with { type: "json"};
-import getMHQuests from "../util/mh/getQuests.js";
 // Splatoon
 import getSplatfests from "../util/splat/getSplatfests.js";
 // DQM3
@@ -56,7 +56,7 @@ const gens = new Generations(Dex);
 let apiHelldivers = "https://helldiverstrainingmanual.com/api/v1/";
 // Persona 5
 // Submodule is documented in persona5 command
-let skillMapRoyal
+let skillMapRoyal;
 eval(fs.readFileSync("submodules/persona5_calculator/data/SkillDataRoyal.js", "utf8").replace("var", ""));
 let personaMapRoyal;
 eval(fs.readFileSync("submodules/persona5_calculator/data/PersonaDataRoyal.js", "utf8").replace("var", ""));
@@ -213,28 +213,34 @@ export default async (client, interaction) => {
                         } else if (interaction.customId.includes("minesweeper")) {
                             // Minesweeper
                             if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them!`, ephemeral: true });
-                            let componentsCopy = interaction.message.components;
-                            for await (let actionRow of componentsCopy) {
-                                const newRow = ActionRowBuilder.from(actionRow);
-                                for await (let button of newRow.components) {
-                                    const newButton = ButtonBuilder.from(button);
-                                    if (newButton.customId == interaction.customId) {
-                                        newButton
+                            let minesweeperComponentsCopy = interaction.message.components;
+                            let componentsReturn = [];
+                            for await (let actionRow of minesweeperComponentsCopy) {
+                                const rowCopy = ActionRowBuilder.from(actionRow);
+                                let rowNew = new ActionRowBuilder();
+                                for await (let button of rowCopy.components) {
+                                    const buttonCopy = ButtonBuilder.from(button);
+                                    if (button.data.custom_id == interaction.customId) {
+                                        buttonCopy
                                             .setStyle(ButtonStyle.Secondary)
+                                            .setEmoji(interaction.customId.split("-")[2])
                                             .setDisabled(true);
+                                        console.log(buttonCopy)
                                     };
+                                    rowNew.addComponents(buttonCopy);
                                 };
-                                console.log(newRow);
+                                componentsReturn.push(rowNew);
                             };
-                            // await componentsCopy.forEach(async function (part, index) {
+                            console.log(componentsReturn[0].components[0])
+
+                            // await minesweeperComponentsCopy.forEach(async function (part, index) {
                             //     await this[index].toJSON().components.forEach(function (part2, index2) {
                             //         if (this[index2].custom_id == interaction.customId) {
                             //             this[index2].emoji.name = interaction.customId.split("-")[2];
                             //             this[index2].disabled = true; // Doesnt work??
                             //         };
                             //     }, this[index].toJSON().components);
-                            // }, componentsCopy);
-                            componentsReturn = componentsCopy;
+                            // }, minesweeperComponentsCopy);
                         } else if (interaction.customId.startsWith("bgd")) {
                             // Trophy shop
                             const offset = parseInt(interaction.customId.substring(3));

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -214,9 +214,9 @@ export default async (client, interaction) => {
                             // Minesweeper
                             if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them!`, ephemeral: true });
                             let componentsCopy = interaction.message.components;
-                            for await (actionRow of componentsCopy) {
+                            for await (let actionRow of componentsCopy) {
                                 const newRow = ActionRowBuilder.from(actionRow);
-                                for await (button of newRow.components) {
+                                for await (let button of newRow.components) {
                                     const newButton = ButtonBuilder.from(button);
                                     if (newButton.customId == interaction.customId) {
                                         newButton

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -212,35 +212,27 @@ export default async (client, interaction) => {
                             componentsReturn = splatfestMessageObject.components;
                         } else if (interaction.customId.includes("minesweeper")) {
                             // Minesweeper
-                            if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them!`, ephemeral: true });
+                            if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them.`, ephemeral: true });
                             let minesweeperComponentsCopy = interaction.message.components;
-                            let componentsReturn = [];
+                            componentsReturn = [];
                             for await (let actionRow of minesweeperComponentsCopy) {
                                 const rowCopy = ActionRowBuilder.from(actionRow);
                                 let rowNew = new ActionRowBuilder();
                                 for await (let button of rowCopy.components) {
                                     const buttonCopy = ButtonBuilder.from(button);
+                                    let buttonEmoji = interaction.customId.split("-")[2];
                                     if (button.data.custom_id == interaction.customId) {
                                         buttonCopy
-                                            .setStyle(ButtonStyle.Secondary)
-                                            .setEmoji(interaction.customId.split("-")[2])
+                                            .setStyle(ButtonStyle.Success)
+                                            .setEmoji(buttonEmoji)
                                             .setDisabled(true);
-                                        console.log(buttonCopy)
+                                        if (buttonEmoji == "💣") buttonCopy.setStyle(ButtonStyle.Danger);
                                     };
                                     rowNew.addComponents(buttonCopy);
                                 };
-                                componentsReturn.push(rowNew);
+                                if (rowNew.components.length > 0) componentsReturn.push(rowNew);
                             };
-                            console.log(componentsReturn[0].components[0])
-
-                            // await minesweeperComponentsCopy.forEach(async function (part, index) {
-                            //     await this[index].toJSON().components.forEach(function (part2, index2) {
-                            //         if (this[index2].custom_id == interaction.customId) {
-                            //             this[index2].emoji.name = interaction.customId.split("-")[2];
-                            //             this[index2].disabled = true; // Doesnt work??
-                            //         };
-                            //     }, this[index].toJSON().components);
-                            // }, minesweeperComponentsCopy);
+                            contentReturn = interaction.message.content;
                         } else if (interaction.customId.startsWith("bgd")) {
                             // Trophy shop
                             const offset = parseInt(interaction.customId.substring(3));

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -214,14 +214,26 @@ export default async (client, interaction) => {
                             // Minesweeper
                             if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them!`, ephemeral: true });
                             let componentsCopy = interaction.message.components;
-                            await componentsCopy.forEach(async function (part, index) {
-                                await this[index].toJSON().components.forEach(function (part2, index2) {
-                                    if (this[index2].custom_id == interaction.customId) {
-                                        this[index2].emoji.name = interaction.customId.split("-")[2];
-                                        this[index2].disabled = true; // Doesnt work??
+                            for await (actionRow of componentsCopy) {
+                                const newRow = ActionRowBuilder.from(actionRow);
+                                for await (button of newRow.components) {
+                                    const newButton = ButtonBuilder.from(button);
+                                    if (newButton.customId == interaction.customId) {
+                                        newButton
+                                            .setStyle(ButtonStyle.Secondary)
+                                            .setDisabled(true);
                                     };
-                                }, this[index].toJSON().components);
-                            }, componentsCopy);
+                                };
+                                console.log(newRow);
+                            };
+                            // await componentsCopy.forEach(async function (part, index) {
+                            //     await this[index].toJSON().components.forEach(function (part2, index2) {
+                            //         if (this[index2].custom_id == interaction.customId) {
+                            //             this[index2].emoji.name = interaction.customId.split("-")[2];
+                            //             this[index2].disabled = true; // Doesnt work??
+                            //         };
+                            //     }, this[index].toJSON().components);
+                            // }, componentsCopy);
                             componentsReturn = componentsCopy;
                         } else if (interaction.customId.startsWith("bgd")) {
                             // Trophy shop

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -216,54 +216,63 @@ export default async (client, interaction) => {
                             // Minesweeper
                             if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them.`, ephemeral: true });
                             let minesweeperComponentsCopy = interaction.message.components;
+
                             componentsReturn = [];
                             let bombEmoji = "💣";
                             let spoilerEmoji = "⬛";
-                            let testBool = true; // DELETE LATER
-                            let testBool2 = true; // DELETE LATER
+                            let clickedButtons = 0;
+                            // ID will only contain the spoiler emoji as a placeholder when no board has been generated yet
+                            let isFirstButton = (minesweeperComponentsCopy[0].components[0].data.custom_id.split("-")[2] == spoilerEmoji);
+                            let isLossState = false;
+                            let isWinState = false;
+
                             // Check if first click
-
-                            // Check if win state
-
-                            // Check if loss state
-                            if (testBool) { // if first button pressed
+                            if (isFirstButton) {
                                 // Build board
-                                const minesweeper = new Minesweeper({
-                                    rows: rows,
-                                    columns: columns,
-                                    mines: mines,
-                                    emote: 'bomb',
-                                    returnType: 'matrix',
-                                });
+                                // const minesweeper = new Minesweeper({
+                                //     rows: rows,
+                                //     columns: columns,
+                                //     mines: mines,
+                                //     emote: 'bomb',
+                                //     returnType: 'matrix',
+                                // });
 
-                                let matrix = minesweeper.start();
-                                matrix.forEach(arr => {
-                                    for (let i = 0; i < arr.length; i++) {
-                                        arr[i] = arr[i].replace("|| :bomb: ||", bombEmote).replace("|| :zero: ||", "0️⃣").replace("|| :one: ||", "1️⃣").replace("|| :two: ||", "2️⃣").replace("|| :three: ||", "3️⃣").replace("|| :four: ||", "4️⃣").replace("|| :five: ||", "5️⃣").replace("|| :six: ||", "6️⃣").replace("|| :seven: ||", "7️⃣").replace("|| :eight: ||", "8️⃣");
+                                // let matrix = minesweeper.start();
+                                // matrix.forEach(arr => {
+                                //     for (let i = 0; i < arr.length; i++) {
+                                //         arr[i] = arr[i].replace("|| :bomb: ||", bombEmote).replace("|| :zero: ||", "0️⃣").replace("|| :one: ||", "1️⃣").replace("|| :two: ||", "2️⃣").replace("|| :three: ||", "3️⃣").replace("|| :four: ||", "4️⃣").replace("|| :five: ||", "5️⃣").replace("|| :six: ||", "6️⃣").replace("|| :seven: ||", "7️⃣").replace("|| :eight: ||", "8️⃣");
+                                //     };
+                                // });
+
+                            };
+                            for await (let actionRow of minesweeperComponentsCopy) {
+                                const rowCopy = ActionRowBuilder.from(actionRow);
+                                let rowNew = new ActionRowBuilder();
+                                for await (let button of rowCopy.components) {
+                                    const buttonCopy = ButtonBuilder.from(button);
+                                    if (isFirstButton) buttonCopy.setCustomId(buttonCopy.data.custom_id.replace(spoilerEmoji, "NEW EMOJI GOES HERE")); // Replace placeholder emoji with generated emoji from above
+                                    let buttonEmoji = interaction.customId.split("-")[2];
+                                    if (button.data.custom_id == interaction.customId) {
+                                        buttonCopy
+                                            .setStyle(ButtonStyle.Success)
+                                            .setEmoji(buttonEmoji)
+                                            .setDisabled(true);
+                                        if (buttonEmoji == bombEmoji) {
+                                            buttonCopy.setStyle(ButtonStyle.Danger);
+                                            isLossState = true;
+                                        };
                                     };
-                                });
-                                // Check if winning state
-                            } else if (testBool2) { // if win state || loss state
-                                // Behaviour for win/lose
+                                    rowNew.addComponents(buttonCopy);
+                                };
+                                if (rowNew.components.length > 0) componentsReturn.push(rowNew);
+
+                            };
+                            // Check if win state
+                            if (isWinState) {
+
+                            } else if (isLossState) {
 
                             } else {
-                                for await (let actionRow of minesweeperComponentsCopy) {
-                                    const rowCopy = ActionRowBuilder.from(actionRow);
-                                    let rowNew = new ActionRowBuilder();
-                                    for await (let button of rowCopy.components) {
-                                        const buttonCopy = ButtonBuilder.from(button);
-                                        let buttonEmoji = interaction.customId.split("-")[2];
-                                        if (button.data.custom_id == interaction.customId) {
-                                            buttonCopy
-                                                .setStyle(ButtonStyle.Success)
-                                                .setEmoji(buttonEmoji)
-                                                .setDisabled(true);
-                                            if (buttonEmoji == bombEmoji) buttonCopy.setStyle(ButtonStyle.Danger);
-                                        };
-                                        rowNew.addComponents(buttonCopy);
-                                    };
-                                    if (rowNew.components.length > 0) componentsReturn.push(rowNew);
-                                };
                                 contentReturn = interaction.message.content;
                             };
                         } else if (interaction.customId.startsWith("bgd")) {

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -37,6 +37,8 @@ import DQMFamiliesJSON from "../submodules/DQM3-db/objects/families.json" with {
 import DQMItemsJSON from "../submodules/DQM3-db/objects/items.json" with { type: "json"};
 import DQMSkillsJSON from "../submodules/DQM3-db/objects/skills.json" with { type: "json"};
 import DQMTalentsJSON from "../submodules/DQM3-db/objects/talents.json" with { type: "json"};
+// Minesweeper
+import Minesweeper from "discord.js-minesweeper";
 // Database
 import { getEphemeralDefault } from "../database/dbServices/user.api.js";
 import {
@@ -78,7 +80,7 @@ export default async (client, interaction) => {
         let pkmQuizModalId = 'pkmQuizModal';
         switch (interaction.type) {
             case InteractionType.ApplicationCommand:
-                // Grab the command data from the client.commands Enmap
+                // Grab the command data from the client.commands collection
                 let cmd;
                 let commandName = interaction.commandName.toLowerCase().replace(" ", "");
                 // Slower? command checker, since some commands user capitalization
@@ -215,24 +217,55 @@ export default async (client, interaction) => {
                             if (!isOriginalUser) return sendMessage({ interaction: interaction, content: `Only ${interaction.message.interaction.user} can use this button as the original interaction was used by them.`, ephemeral: true });
                             let minesweeperComponentsCopy = interaction.message.components;
                             componentsReturn = [];
-                            for await (let actionRow of minesweeperComponentsCopy) {
-                                const rowCopy = ActionRowBuilder.from(actionRow);
-                                let rowNew = new ActionRowBuilder();
-                                for await (let button of rowCopy.components) {
-                                    const buttonCopy = ButtonBuilder.from(button);
-                                    let buttonEmoji = interaction.customId.split("-")[2];
-                                    if (button.data.custom_id == interaction.customId) {
-                                        buttonCopy
-                                            .setStyle(ButtonStyle.Success)
-                                            .setEmoji(buttonEmoji)
-                                            .setDisabled(true);
-                                        if (buttonEmoji == "💣") buttonCopy.setStyle(ButtonStyle.Danger);
+                            let bombEmoji = "💣";
+                            let spoilerEmoji = "⬛";
+                            let testBool = true; // DELETE LATER
+                            let testBool2 = true; // DELETE LATER
+                            // Check if first click
+
+                            // Check if win state
+
+                            // Check if loss state
+                            if (testBool) { // if first button pressed
+                                // Build board
+                                const minesweeper = new Minesweeper({
+                                    rows: rows,
+                                    columns: columns,
+                                    mines: mines,
+                                    emote: 'bomb',
+                                    returnType: 'matrix',
+                                });
+
+                                let matrix = minesweeper.start();
+                                matrix.forEach(arr => {
+                                    for (let i = 0; i < arr.length; i++) {
+                                        arr[i] = arr[i].replace("|| :bomb: ||", bombEmote).replace("|| :zero: ||", "0️⃣").replace("|| :one: ||", "1️⃣").replace("|| :two: ||", "2️⃣").replace("|| :three: ||", "3️⃣").replace("|| :four: ||", "4️⃣").replace("|| :five: ||", "5️⃣").replace("|| :six: ||", "6️⃣").replace("|| :seven: ||", "7️⃣").replace("|| :eight: ||", "8️⃣");
                                     };
-                                    rowNew.addComponents(buttonCopy);
+                                });
+                                // Check if winning state
+                            } else if (testBool2) { // if win state || loss state
+                                // Behaviour for win/lose
+
+                            } else {
+                                for await (let actionRow of minesweeperComponentsCopy) {
+                                    const rowCopy = ActionRowBuilder.from(actionRow);
+                                    let rowNew = new ActionRowBuilder();
+                                    for await (let button of rowCopy.components) {
+                                        const buttonCopy = ButtonBuilder.from(button);
+                                        let buttonEmoji = interaction.customId.split("-")[2];
+                                        if (button.data.custom_id == interaction.customId) {
+                                            buttonCopy
+                                                .setStyle(ButtonStyle.Success)
+                                                .setEmoji(buttonEmoji)
+                                                .setDisabled(true);
+                                            if (buttonEmoji == bombEmoji) buttonCopy.setStyle(ButtonStyle.Danger);
+                                        };
+                                        rowNew.addComponents(buttonCopy);
+                                    };
+                                    if (rowNew.components.length > 0) componentsReturn.push(rowNew);
                                 };
-                                if (rowNew.components.length > 0) componentsReturn.push(rowNew);
+                                contentReturn = interaction.message.content;
                             };
-                            contentReturn = interaction.message.content;
                         } else if (interaction.customId.startsWith("bgd")) {
                             // Trophy shop
                             const offset = parseInt(interaction.customId.substring(3));


### PR DESCRIPTION
To Do:
- [x] Move board generation to first button click.
- [x] Disable button after being activated
- [x] Handle win/loss state
  - [x] Check for win state. Check for `B-M=R` where `B` is the board size, `M` is the amount of mines and `R` is the amount of tiles revealed.
  - [x] Check for loss state.
  - [x] Disable all buttons on win/loss state
  - [x] Convert board to text to return the full, revealed board as text emotes
  - [x] Reward money on win

Closes #887 