### PR TITLE
feat | chore: shiny charm leftovers; trophy logic

### DIFF
--- a/commands/api/splatoon.js
+++ b/commands/api/splatoon.js
@@ -33,7 +33,7 @@ fs.readdir("./submodules/splat3/data/language/", (err, files) => {
         const fileName = file.split(".")[0];
         if (!fileName.endsWith("_full")) return; // Skip to next iteration, only count full language files
         const languageKey = fileName.split("_")[0];
-        const languageJSON = await import(`../../submodules/splat3/data/language/${file}`, { assert: { type: "json" } });
+        const languageJSON = await import(`../../submodules/splat3/data/language/${file}`, { with: { type: "json" } });
         globalVars.splatoon3.languageJSONs[languageKey] = languageJSON.default;
     });
 });

--- a/commands/virtual_simulation/shinx.js
+++ b/commands/virtual_simulation/shinx.js
@@ -318,7 +318,7 @@ export default async (interaction, messageFlags) => {
                 messageFile = new AttachmentBuilder(canvas.toBuffer());
             } else {
                 messageFlags.add(MessageFlags.Ephemeral);
-                returnString = 'Your Shinx needs to be at least level 50 to make it shiny.';
+                returnString = 'You need to obtain the Shiny Charm trophy to change your Shinx\'s shininess.\n\n💡 you might get it if you level up your Shinx during battle to level 50 or above.';
                 messageFile = null;
             };
             return sendMessage({ interaction: interaction, content: returnString, files: messageFile, flags: messageFlags });

--- a/database/dbServices/shinx.api.js
+++ b/database/dbServices/shinx.api.js
@@ -69,6 +69,8 @@ export async function checkBattleTrophies(id, level) {
     if (level >= 50) await addEventTrophy(id, 'Shiny Charm');
 };
 
+
+
 export async function hasEventTrophy(user_id, trophy_id) {
     const { EventTrophy } = await userdataModel(userdata);
     const { User } = await userdataModel(userdata);
@@ -98,6 +100,11 @@ export async function addEventTrophy(user_id, trophy_id) {
         await user.addEventTrophy(trophy_id);
     };
 };
+
+export async function addExperience(id, experience) {
+    let shinx = await getShinx(id, ['user_id', 'experience']);
+    await shinx.addExperienceAndLevelUp(experience);
+}
 
 export async function feedShinx(id) {
     let shinx = await getShinx(id, ['user_id', 'belly', 'experience']);

--- a/database/dbServices/trophy.api.js
+++ b/database/dbServices/trophy.api.js
@@ -180,44 +180,12 @@ export async function buyShopTrophy(user_id, trophy_id) {
     let trophy = trophies.find(elem => elem.trophy_id.toLowerCase() == trophy_id_t);
     if (!trophy) return 'NoTrophy';
     let user = await getUser(user_id, ['user_id', 'money']);
-    if (await user.hasShopTrophy(trophy)) return 'HasTrophy';
+    if (await user.hasShopTrophy(trophy.trophy_id)) return 'HasTrophy';
     if (user.money < trophy.price) return 'NoMoney';
 
-    await user.addShopTrophy(trophy);
+    await user.addShopTrophy(trophy.trophy_id);
     await user.addMoney(-trophy.price);
     return 'Ok';
-};
-
-export async function addEventTrophy(user_id, trophy_id) {
-    const { EventTrophy } = await userdataModel(userdata);
-    let user = await getUser(user_id, ['user_id']);
-    let trophy_id_t = trophy_id.toLowerCase();
-    const trophy = await EventTrophy.findOne(
-        { attributes: ['trophy_id'], where: where(fn('lower', col('trophy_id')), trophy_id_t) }
-    );
-
-    if (!(await user.hasEventTrophy(trophy))) await user.addEventTrophy(trophy);
-};
-
-export async function hasEventTrophy(user_id, trophy_id) {
-    const { EventTrophy } = await userdataModel(userdata);
-    let user = await getUser(user_id, ['user_id']);
-    let trophy_id_t = trophy_id.toLowerCase();
-    const trophy = await EventTrophy.findOne(
-        { attributes: ['trophy_id'], where: where(fn('lower', col('trophy_id')), trophy_id_t) }
-    );
-
-    return (await user.hasEventTrophy(trophy));
-};
-
-export async function addEventTrophyUnchecked(user_id, trophy_id) {
-    const { EventTrophy } = await userdataModel(userdata);
-    let user = await getUser(user_id, ['user_id']);
-    let trophy_id_t = trophy_id.toLowerCase();
-    const trophy = await EventTrophy.findOne(
-        { attributes: ['trophy_id'], where: where(fn('lower', col('trophy_id')), trophy_id_t) }
-    );
-    await user.addEventTrophy(trophy);
 };
 
 export async function getEventTrophies() {

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -790,14 +790,14 @@ export default async (client, interaction) => {
                         switch (focusedOption.name) {
                             case "name":
                                 switch (interaction.options.getSubcommand()) {
-                                    case "shoptrophy":
+                                    case "buy":
                                         const buyable_items = await getBuyableShopTrophies(interaction.user.id);
                                         buyable_items.forEach(trophy => {
                                             choices.push({ name: trophy, value: trophy });
                                         });
                                         // if (choices.length == 0) choices.push({ name: "You need more money in order to buy!", value: "1"});
                                         break;
-                                    case "trophy":
+                                    case "info":
                                         let trophies = await getShopTrophies();
                                         let temp = '';
                                         trophies.forEach(trophy => {

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -69,7 +69,7 @@ fs.readdir("./submodules/pokemon-tcg-data/cards/en", (err, files) => {
     files.forEach(async (file) => {
         const fileName = file.split(".")[0];
         if (!pokemonCardsBySet[fileName]) pokemonCardsBySet[fileName] = [];
-        const setJSON = await import(`../submodules/pokemon-tcg-data/cards/en/${file}`, { assert: { type: "json" } });
+        const setJSON = await import(`../submodules/pokemon-tcg-data/cards/en/${file}`, { with: { type: "json" } });
         setJSON.default.forEach(card => {
             pokemonCardsBySet[fileName].push(card);
             pokemonCardsAll.push(card);


### PR DESCRIPTION
## Shiny Charm
- bugfix: Restore addExperience for owner commands compatibility
- refactor: Change shiny charm unavailable message
## Trophies
- Fixes #1032 
- bugfix: Write correctly trophy autocomplete logic
- bugfix: Fix buying trophies; Remove unused functions
## Setup
- bugfix: fix json require on submodules on newer node versions



